### PR TITLE
fix: default to tcp probe

### DIFF
--- a/itscontained/traefik-forward-auth/templates/deployment.yaml
+++ b/itscontained/traefik-forward-auth/templates/deployment.yaml
@@ -183,15 +183,19 @@ spec:
             - name: http
               containerPort: 4181
               protocol: TCP
+        {{- $livenessProbe := .Values.livenessProbe }}
+        {{- if $livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+          {{- $livenessProbe := unset $livenessProbe "enabled" }}
+          {{- toYaml $livenessProbe | nindent 12 }}
+        {{- end }}
+        {{- $readinessProbe := .Values.readinessProbe }}
+        {{- if $readinessProbe.enabled }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
-          {{- with .Values.resources }}
+            {{- $readinessProbe := unset $readinessProbe "enabled" }}
+            {{- toYaml $readinessProbe | nindent 12 }}
+        {{- end }}
+        {{- with .Values.resources }}
           resources:
       {{- toYaml . | nindent 12 }}
       {{- end }}

--- a/itscontained/traefik-forward-auth/values.yaml
+++ b/itscontained/traefik-forward-auth/values.yaml
@@ -111,6 +111,18 @@ service:
   labels: {}
   additionalSpec: {}
 
+livenessProbe:
+  enabled: true
+  tcpSocket:
+    port: http
+  periodSeconds: 20
+
+readinessProbe:
+  enabled: true
+  tcpSocket:
+    port: http
+  periodSeconds: 10
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
Defaults to tcpProbe for liveness and readiness probe as traefik forward auth does not implement http liveness or readiness handlers. Allows overriding the probes fully to make any changes to default settings possible.